### PR TITLE
Add ocaml.org, remove 404ed link, add warning

### DIFF
--- a/learning/best_practices.md
+++ b/learning/best_practices.md
@@ -12,10 +12,6 @@ These three guides are very similar.  Some people have found them useful, but be
 * [Cornell Code Style](http://www.cs.cornell.edu/Courses/cs312/2001sp/style.html) 
 * [UPenn Code Style](https://www.seas.upenn.edu/~cis120/current/programming_style.shtml)
 
-<!-- This is 404'ed.  I'll write to Pyrocat101 to find out more.
-Pyrocat OCaml Style Guide : https://github.com/pyrocat101/ocaml-style-guide
--->
-
 ## Documentation Best Practices
 
 * [Documentation Guidelines](https://github.com/bobbypriambodo/ocaml-documentation-guideline) : NOTE: consider pulling inline with Bobby's permission.

--- a/learning/best_practices.md
+++ b/learning/best_practices.md
@@ -8,8 +8,8 @@ Here is a collection of best practices for successful programming in OCaml.
 
 These two guides are very similar.  Some people have found them useful, but be aware that some of the code examples are not valid OCaml:
 
-* [UPenn CIS500 Programming Style](https://www.seas.upenn.edu/~cis500/cis500-f06/resources/programming_style.html) 
 * [UPenn CIS120 Code Style](https://www.seas.upenn.edu/~cis120/current/programming_style.shtml)
+* [UPenn CIS500 Programming Style](https://www.seas.upenn.edu/~cis500/cis500-f06/resources/programming_style.html) 
 
 ## Documentation Best Practices
 

--- a/learning/best_practices.md
+++ b/learning/best_practices.md
@@ -6,10 +6,10 @@ Here is a collection of best practices for successful programming in OCaml.
 * [XEN – OCaml Best Practices for Developers](http://wiki.xen.org/wiki/OCaml_Best_Practices_for_Developers) 
 * [Jane Street Style](https://opensource.janestreet.com/standards/)
 
-These three guides are very similar.  Some people have found them useful, but be aware that some of the code examples are not valid OCaml:
+These two guides are very similar.  Some people have found them useful, but be aware that some of the code examples are not valid OCaml:
 
-* [CIS500 Programming Style](https://www.seas.upenn.edu/~cis500/cis500-f06/resources/programming_style.html) 
-* [UPenn Code Style](https://www.seas.upenn.edu/~cis120/current/programming_style.shtml)
+* [UPenn CIS500 Programming Style](https://www.seas.upenn.edu/~cis500/cis500-f06/resources/programming_style.html) 
+* [UPenn CIS120 Code Style](https://www.seas.upenn.edu/~cis120/current/programming_style.shtml)
 
 ## Documentation Best Practices
 

--- a/learning/best_practices.md
+++ b/learning/best_practices.md
@@ -9,7 +9,6 @@ Here is a collection of best practices for successful programming in OCaml.
 These three guides are very similar.  Some people have found them useful, but be aware that some of the code examples are not valid OCaml:
 
 * [CIS500 Programming Style](https://www.seas.upenn.edu/~cis500/cis500-f06/resources/programming_style.html) 
-* [Cornell Code Style](http://www.cs.cornell.edu/Courses/cs312/2001sp/style.html) 
 * [UPenn Code Style](https://www.seas.upenn.edu/~cis120/current/programming_style.shtml)
 
 ## Documentation Best Practices

--- a/learning/best_practices.md
+++ b/learning/best_practices.md
@@ -2,12 +2,19 @@
 
 Here is a collection of best practices for successful programming in OCaml.
 
+* [OCaml programming guidelines at ocaml.org](http://www.ocaml.org/learn/tutorials/guidelines.html)
 * [XEN – OCaml Best Practices for Developers](http://wiki.xen.org/wiki/OCaml_Best_Practices_for_Developers) 
-* [Pyrocat OCaml Style Guide](https://github.com/pyrocat101/ocaml-style-guide) 
+* [Jane Street Style](https://opensource.janestreet.com/standards/)
+
+These three guides are very similar.  Some people have found them useful, but be aware that some of the code examples are not valid OCaml:
+
 * [CIS500 Programming Style](https://www.seas.upenn.edu/~cis500/cis500-f06/resources/programming_style.html) 
 * [Cornell Code Style](http://www.cs.cornell.edu/Courses/cs312/2001sp/style.html) 
 * [UPenn Code Style](https://www.seas.upenn.edu/~cis120/current/programming_style.shtml)
-* [Jane Street Style](https://opensource.janestreet.com/standards/)
+
+<!-- This is 404'ed.  I'll write to Pyrocat101 to find out more.
+Pyrocat OCaml Style Guide : https://github.com/pyrocat101/ocaml-style-guide
+-->
 
 ## Documentation Best Practices
 


### PR DESCRIPTION
1. Added ocaml.org style guide.

2. Removed a broken link that was probably for an OCaml style guide like the two Penn guides and the Cornell guide (which may be identical except for formatting, etc.).    

3. Added note saying that the latter three guides are similar, and warning that they include non-compiling, not-OCaml code.

Please see my commit comments for further clarification.