### PR TITLE
Plus/Minus symbol should be easier to see

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -108,7 +108,6 @@ img {
         &:after {
             content: '\FF0B'; /* Unicode character for "plus" sign (+) */
             font-size: 13px;
-            color: white;
             float: right;
             margin-left: 5px;
         }


### PR DESCRIPTION
Removes the `color:white` for the `+` and `-` symbols on the sidebar

**Before:**
![screen shot 2018-08-29 at 5 12 43 pm](https://user-images.githubusercontent.com/5814535/44816103-43356780-abaf-11e8-9f2f-adfd03cdc0ae.png)

**After:**
![screen shot 2018-08-29 at 5 16 04 pm](https://user-images.githubusercontent.com/5814535/44816139-5f390900-abaf-11e8-8c92-d62917524d06.png)
