### PR TITLE
Mantis no longer in use

### DIFF
--- a/content/community.md
+++ b/content/community.md
@@ -23,9 +23,6 @@ Some people aren't on Discourse but *are* subscribed to the mailing list.
 contains both news and discussions about OCaml, but tends to have minimal traffic.
 * [The OCaml github page](https://github.com/ocaml/ocaml):
 where development and some discussion on the internals of the OCaml language takes place.
-* [OCaml Mantis](https://caml.inria.fr/mantis/main_page.php):
-Bugs with the compiler, runtime or language are reported here rather than on github.
-You'll need to sign up for an account.
 
 ## OCaml News
 


### PR DESCRIPTION
- Compiler bugs are now reported on Github
- Announcement about change on OCaml mailing list https://sympa.inria.fr/sympa/arc/caml-list/2019-03/msg00018.html