### PR TITLE
the HTTP/2 implementation is called h2

### DIFF
--- a/content/web_networking.md
+++ b/content/web_networking.md
@@ -8,7 +8,7 @@ tags: [ecosystem]
 
 * [httpaf](https://github.com/inhabitedtype/httpaf):
 A high performance web server written in OCaml. Compatible with Async and Lwt.
-* [http2af](https://github.com/anmonteiro/http2af):
+* [h2](https://github.com/anmonteiro/ocaml-h2):
 High performance http2 server.
 * [cohttp](https://github.com/mirage/ocaml-cohttp):
 An alternative, lightweight HTTP server.


### PR DESCRIPTION
Because of reasons