### PR TITLE
Add ocaml-protoc and bin_prot serialization

### DIFF
--- a/content/file_formats.md
+++ b/content/file_formats.md
@@ -20,6 +20,8 @@ extensible binary data format, like JSON but faster.
 a streaming codec to decode and encode the XML data format.
 * [sexplib](https://github.com/janestreet/sexplib):
 a S-expression parser and printer
+* [ocaml-protoc](https://github.com/mransan/ocaml-protoc) pure OCaml implementation of [Protobuf](https://developers.google.com/protocol-buffers/) with binary, Yojson and BuckleScript JSON support.
+* [bin_prot](https://github.com/janestreet/bin_prot) efficient, type-safe binary protocol specific to OCaml.
 * [camlon](https://bitbucket.org/camlspotter/camlon):
 configuration and serialization format similar to JSON but with an OCaml feel.
 


### PR DESCRIPTION
I noticed these were missing from the list.

The [ocaml-protoc](https://github.com/mransan/ocaml-protoc) and the related [ocaml-protoc-yojson](https://github.com/mransan/ocaml-protoc-yojson) and [bs-ocaml-protoc-json](https://github.com/mransan/bs-ocaml-protoc-json) are 2 years old, but gave me no issues so far in my testing.

I haven't used Jane Street's [Bin_prot](https://github.com/janestreet/bin_prot) personally, but I think it is worth mentioning.