### PR TITLE
Attempt to fix a quoting error

### DIFF
--- a/content/weak_type_variables.md
+++ b/content/weak_type_variables.md
@@ -222,7 +222,7 @@ looks like a constant is a constant) to a semantic definition
 (something that acts like a constant is a constant).
 
 For example, this rule allows the following expressions to have
-polymorphic type: `lazy None`, ` let _ = ref None in 1`, and even
+polymorphic type: `lazy None`, `let _ = ref None in 1`, and even
 `assert false`.
 
 However, the expression `(fun _ _ -> 0) ()` will be given a


### PR DESCRIPTION
Note the improper quoting at https://ocamlverse.github.io/content/weak_type_variables.html#:~:text=let%20_%20%3D%20ref%20None%20in%201

![image](https://user-images.githubusercontent.com/396076/116925796-a82aa080-ac27-11eb-913b-613bdecfc7b7.png)

I'm not sure if this will fix it, and I suspect this indicates a deeper bug in the procedure turning markdown into HTML, but this seems like it might fix the surface-level problem here.
