### PR TITLE
Clarify why Str is not recommended

### DIFF
--- a/content/regular_expressions.md
+++ b/content/regular_expressions.md
@@ -17,5 +17,4 @@ This is a binding on top of Re.
 [Str](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Str.html) module.
 This module is __not__ recommended because it is not part of the standard library,
 it uses global states and is not particularly fast, but its availability makes it
-useful when you don't have access to anything better.  It is partially implemented
-in C and thus not available in `js_of_ocaml`.
+useful when you don't have access to anything better.

--- a/content/regular_expressions.md
+++ b/content/regular_expressions.md
@@ -13,8 +13,8 @@ matched groups.
 * [Humane-re](https://github.com/rgrinberg/humane-re): attempts to provide an easy
 interface for 90% of your regex needs.
 This is a binding on top of Re.
-* The standard library contains the
+* OCaml comes with the
 [Str](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Str.html) module.
-This module is __not__ recommended,
-but its availability in the standard library makes it useful when you don't
-have access to anything better.
+This module is __not__ recommended because it is not part of the standard library,
+it uses global states and is not particularly fast, but its availability makes it
+useful when you don't have access to anything better.

--- a/content/regular_expressions.md
+++ b/content/regular_expressions.md
@@ -17,4 +17,5 @@ This is a binding on top of Re.
 [Str](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Str.html) module.
 This module is __not__ recommended because it is not part of the standard library,
 it uses global states and is not particularly fast, but its availability makes it
-useful when you don't have access to anything better.
+useful when you don't have access to anything better.  It is partially implemented
+in C and thus not available in `js_of_ocaml`.


### PR DESCRIPTION
Based on an exchange with `@octachron` and `@hhugo` on Discord, I have added the reasons why `Str` is not recommended.