### PR TITLE
Use `opam var share` instead of `opam config var share`

### DIFF
--- a/content/editor_setup.md
+++ b/content/editor_setup.md
@@ -25,7 +25,7 @@ In order to just have basic Merlin support, all you need is to add this snippet 
 
 ```
 if executable('opam')
-  let g:opamshare=substitute(system('opam config var share'),'\n$','','''')
+  let g:opamshare=substitute(system('opam var share'),'\n$','','''')
   if isdirectory(g:opamshare."/merlin/vim")
     execute "set rtp+=" . g:opamshare."/merlin/vim"
   endif


### PR DESCRIPTION
`opam config var share` on my system outputs:

```
$ opam config var share                                                         
[WARNING] var was deprecated in version 2.1 of the opam CLI. Use opam var instead or set OPAMCLI environment variable to 2.0.
/home/xyene/.opam/4.13.1/share
```

which prevents the substitution from working, and Merlin from getting loaded.