### PR TITLE
issue-137: delete a link rot of OWL on the Help Wanted page

### DIFF
--- a/content/help_wanted.md
+++ b/content/help_wanted.md
@@ -48,8 +48,6 @@ complete as GTK2 state, see `lablgtk3` branch.
 
 * [OWL](https://github.com/owlbarn/owl) (needs help):
 OCaml's equivalent to numpy, scipy and Pytorch/Tensorflow.
-  * [OWL proposed project page](https://ocaml.xyz/project/proposal.html):
-  List of proposed projects for people interested in helping develop `OWL`.
   
 ## Cloud Technology
 


### PR DESCRIPTION
This code is related to #137 

Deleting a link rot of OWL on the Help Wanted page.

Please help to review! @bluddy 