### PR TITLE
Update databases

### DIFF
--- a/content/databases.md
+++ b/content/databases.md
@@ -6,9 +6,12 @@ tags: [ecosystem]
 
 ## Bindings
 
+_Note: Libraries with over 100 stars on GitHub as of 2023-05-15 are marked "Popular"._
+
 * [camltc](https://github.com/toolslive/camltc): OCaml bindings to [Tokyo Cabinet](https://github.com/Incubaid/tokyocabinet).
 * [Caqti](https://github.com/paurkedal/ocaml-caqti): monadic, asynchronous common interface to relational databases.
   * Currently supports MariaDB, PostgreSQL and SQLite3.
+  * Popular
 * [Dbm](https://forge.ocamlcore.org/projects/camldbm/): a binding to the NDBM/GDBM Unix "databases".
 * [ezpostgresql](https://github.com/bobbypriambodo/ezpostgresql): simple, non-type-safe interface to PostgreSQL. Prioritizes simplicity.
   * Wraps around PostgreSQL-OCaml.
@@ -23,13 +26,18 @@ tags: [ecosystem]
 * [Petrol](https://github.com/gopiandcode/petrol): Provides a high-level, type-safe API that allows defining SQL tables and queries directly in OCaml rather than writing SQL code.
 * [PG'OCaml](https://github.com/darioteixeira/pgocaml): PostgreSQL client in pure OCaml.
   * Includes a `PPX` that provides compile-time checking of SQL syntax and types.
+  * Popular
 * [PGX](https://github.com/arenadotio/pgx): a pure-OCaml PostgreSQL client library, supporting Async, LWT, or synchronous operations.
+  * Popular
 * [PostgreSQL-OCaml](https://mmottl.github.io/postgresql-ocaml/): a low-level interface to PostgreSQL through the C API (`libpq`).
+  * Popular
 * [ppx_mysql](https://github.com/issuu/ppx_mysql): Syntax extension for mysql bindings.
   * [Blog post](https://engineering.issuu.com/2019/05/06/announcing-ppx-mysql).
 * [ppx_pgsql](https://github.com/tizoc/ppx_pgsql): a syntax extension for embedded SQL queries using PG'OCaml.
 * [ppx_rapper](https://github.com/roddyyaga/ppx_rapper): a syntax extension for PostgreSQL using Caqti
+  * Popular
 * [SQLite3-OCaml](https://github.com/mmottl/sqlite3-ocaml/): OCaml bindings to the SQLite3 database.
+  * Popular
 * [Sqlite3EZ](https://mlin.github.io/ocaml-sqlite3EZ/): thin wrapper for SQLite3 with a simplified interface.
 
 ### Out of Date

--- a/content/databases.md
+++ b/content/databases.md
@@ -7,21 +7,26 @@ tags: [ecosystem]
 ## Bindings
 
 * [camltc](https://github.com/toolslive/camltc): OCaml bindings to [Tokyo Cabinet](https://github.com/Incubaid/tokyocabinet).
-* [Caqti](https://github.com/paurkedal/ocaml-caqti): monadic, asynchronous common interface to relational databases. Currently supports MariaDB, PostgreSQL and SQLite3.
+* [Caqti](https://github.com/paurkedal/ocaml-caqti): monadic, asynchronous common interface to relational databases.
+  * Currently supports MariaDB, PostgreSQL and SQLite3.
 * [Dbm](https://forge.ocamlcore.org/projects/camldbm/): a binding to the NDBM/GDBM Unix "databases".
-* [ezpostgresql](https://github.com/bobbypriambodo/ezpostgresql): simple, non-type-safe interface to PostgreSQL. Prioritizes simplicity. Wraps around PostgreSQL-OCaml.
+* [ezpostgresql](https://github.com/bobbypriambodo/ezpostgresql): simple, non-type-safe interface to PostgreSQL. Prioritizes simplicity.
+  * Wraps around PostgreSQL-OCaml.
 * [Mongo](https://massd.github.io/mongo/): OCaml driver for Mongodb
-* [mysql8](https://github.com/chrisnevers/mysql8): Bindings to the latest version of the mysql database. [docs](https://chrisnevers.github.io/mysql8/mysql8/index.html)
+* [mysql8](https://github.com/chrisnevers/mysql8): Bindings to the latest version of the mysql database.
+  * [docs](https://chrisnevers.github.io/mysql8/mysql8/index.html)
 * [mysql_protocol](https://github.com/slegrand45/mysql_protocol): implementation of MySQL Protocol with the Bitstring library.
 * [OCaml-mariahdb](https://github.com/andrenth/ocaml-mariadb): OCaml bindings to MariahDB interface.
 * [ocaml-redis](https://github.com/0xffea/ocaml-redis): Redis bindings for OCaml.
 * [ocaml-sql-query](https://github.com/yawaramin/ocaml_sql_query): Experimental functional wrapper over SQL queries.
 * [orocksdb](https://github.com/domsj/orocksdb): OCaml RocksDB bindings using ctypes.
 * [Petrol](https://github.com/gopiandcode/petrol): Provides a high-level, type-safe API that allows defining SQL tables and queries directly in OCaml rather than writing SQL code.
-* [PG'OCaml](https://github.com/darioteixeira/pgocaml): PostgreSQL client in pure OCaml. Includes a `PPX` that provides compile-time checking of SQL syntax and types.
+* [PG'OCaml](https://github.com/darioteixeira/pgocaml): PostgreSQL client in pure OCaml.
+  * Includes a `PPX` that provides compile-time checking of SQL syntax and types.
 * [PGX](https://github.com/arenadotio/pgx): a pure-OCaml PostgreSQL client library, supporting Async, LWT, or synchronous operations.
 * [PostgreSQL-OCaml](https://mmottl.github.io/postgresql-ocaml/): a low-level interface to PostgreSQL through the C API (`libpq`).
-* [ppx_mysql](https://github.com/issuu/ppx_mysql): Syntax extension for mysql bindings. [Blog post](https://engineering.issuu.com/2019/05/06/announcing-ppx-mysql).
+* [ppx_mysql](https://github.com/issuu/ppx_mysql): Syntax extension for mysql bindings.
+  * [Blog post](https://engineering.issuu.com/2019/05/06/announcing-ppx-mysql).
 * [ppx_pgsql](https://github.com/tizoc/ppx_pgsql): a syntax extension for embedded SQL queries using PG'OCaml.
 * [ppx_rapper](https://github.com/roddyyaga/ppx_rapper): a syntax extension for PostgreSQL using Caqti
 * [SQLite3-OCaml](https://github.com/mmottl/sqlite3-ocaml/): OCaml bindings to the SQLite3 database.
@@ -30,7 +35,8 @@ tags: [ecosystem]
 ### Out of Date
 
 * [mysql](http://ocaml-mysql.forge.ocamlcore.org/): (Older version of mysql) mysql library.
-* [Sequoia](https://github.com/andrenth/sequoia): (Needs update to latest OCaml) Create type-safe queries. Currently with bindings to MySQL/MariaDB and SQLite.
+* [Sequoia](https://github.com/andrenth/sequoia): (Needs update to latest OCaml) Create type-safe queries.
+  * Currently with bindings to MySQL/MariaDB and SQLite.
 
 ## OCaml Databases
 

--- a/content/databases.md
+++ b/content/databases.md
@@ -31,6 +31,7 @@ Syntax extension for mysql bindings. [Blog post](https://engineering.issuu.com/2
 * [camltc](https://github.com/toolslive/camltc): OCaml bindings to [Tokyo Cabinet](https://github.com/Incubaid/tokyocabinet).
 * [orocksdb](https://github.com/domsj/orocksdb): OCaml RocksDB bindings using ctypes.
 * [ppx_rapper](https://github.com/roddyyaga/ppx_rapper): a syntax extension for PostgreSQL using Caqti
+* [Petrol](https://github.com/gopiandcode/petrol): Provides a high-level, type-safe API that allows defining SQL tables and queries directly in OCaml rather than writing SQL code.
 
 ### Out of Date
 * [Sequoia](https://github.com/andrenth/sequoia):
@@ -57,3 +58,4 @@ mysql library.
 
 * [Implementing the Binary Memcached Protocol with Ocaml and Bitstring](http://andreas.github.io/2014/08/22/implementing-the-binary-memcached-protocol-with-ocaml-and-bitstring/)
 * [Interfacing OCaml and PostgreSQL with Caqti](https://medium.com/@bobbypriambodo/interfacing-ocaml-and-postgresql-with-caqti-a92515bdaa11)
+* [Petrol: embedding a type-safe SQL API in OCaml using GADTs](https://gopiandcode.uk/logs/log-ways-of-sql-in-ocaml.html)

--- a/content/databases.md
+++ b/content/databases.md
@@ -6,48 +6,39 @@ tags: [ecosystem]
 
 ## Bindings
 
-* [Caqti](https://github.com/paurkedal/ocaml-caqti): monadic, asynchronous common interface to relational databases.
-Currently supports MariaDB, PostgreSQL and SQLite3.
-* [Mongo](https://massd.github.io/mongo/): OCaml driver for Mongodb
-* [OCaml-mariahdb](https://github.com/andrenth/ocaml-mariadb): OCaml bindings to MariahDB interface.
-* [PG'OCaml](https://github.com/darioteixeira/pgocaml):
-  PostgreSQL client in pure OCaml. Includes a `PPX` that provides compile-time checking of SQL syntax and types.
-* [ppx_pgsql](https://github.com/tizoc/ppx_pgsql): a syntax extension for embedded SQL queries using PG'OCaml.
-* [PostgreSQL-OCaml](https://mmottl.github.io/postgresql-ocaml/): a low-level interface to PostgreSQL through the C API (`libpq`).
-* [ezpostgresql](https://github.com/bobbypriambodo/ezpostgresql): simple, non-type-safe interface to PostgreSQL.
-Prioritizes simplicity. Wraps around PostgreSQL-OCaml.
-* [PGX](https://github.com/arenadotio/pgx): a pure-OCaml PostgreSQL client library, supporting Async, LWT, or synchronous operations.
-* [SQLite3-OCaml](https://github.com/mmottl/sqlite3-ocaml/): OCaml bindings to the SQLite3 database.
-* [ocaml-sql-query](https://github.com/yawaramin/ocaml_sql_query): Experimental functional wrapper over SQL queries.
-* [Sqlite3EZ](https://mlin.github.io/ocaml-sqlite3EZ/): thin wrapper for SQLite3 with a simplified interface.
-* [ocaml-redis](https://github.com/0xffea/ocaml-redis): Redis bindings for OCaml.
-* [mysql8](https://github.com/chrisnevers/mysql8):
-Bindings to the latest version of the mysql database.
-[docs](https://chrisnevers.github.io/mysql8/mysql8/index.html)
-* [ppx_mysql](https://github.com/issuu/ppx_mysql):
-Syntax extension for mysql bindings. [Blog post](https://engineering.issuu.com/2019/05/06/announcing-ppx-mysql).
-* [mysql_protocol](https://github.com/slegrand45/mysql_protocol): implementation of MySQL Protocol with the Bitstring library.
-* [Dbm](https://forge.ocamlcore.org/projects/camldbm/): a binding to the NDBM/GDBM Unix "databases".
 * [camltc](https://github.com/toolslive/camltc): OCaml bindings to [Tokyo Cabinet](https://github.com/Incubaid/tokyocabinet).
+* [Caqti](https://github.com/paurkedal/ocaml-caqti): monadic, asynchronous common interface to relational databases. Currently supports MariaDB, PostgreSQL and SQLite3.
+* [Dbm](https://forge.ocamlcore.org/projects/camldbm/): a binding to the NDBM/GDBM Unix "databases".
+* [ezpostgresql](https://github.com/bobbypriambodo/ezpostgresql): simple, non-type-safe interface to PostgreSQL. Prioritizes simplicity. Wraps around PostgreSQL-OCaml.
+* [Mongo](https://massd.github.io/mongo/): OCaml driver for Mongodb
+* [mysql8](https://github.com/chrisnevers/mysql8): Bindings to the latest version of the mysql database. [docs](https://chrisnevers.github.io/mysql8/mysql8/index.html)
+* [mysql_protocol](https://github.com/slegrand45/mysql_protocol): implementation of MySQL Protocol with the Bitstring library.
+* [OCaml-mariahdb](https://github.com/andrenth/ocaml-mariadb): OCaml bindings to MariahDB interface.
+* [ocaml-redis](https://github.com/0xffea/ocaml-redis): Redis bindings for OCaml.
+* [ocaml-sql-query](https://github.com/yawaramin/ocaml_sql_query): Experimental functional wrapper over SQL queries.
 * [orocksdb](https://github.com/domsj/orocksdb): OCaml RocksDB bindings using ctypes.
-* [ppx_rapper](https://github.com/roddyyaga/ppx_rapper): a syntax extension for PostgreSQL using Caqti
 * [Petrol](https://github.com/gopiandcode/petrol): Provides a high-level, type-safe API that allows defining SQL tables and queries directly in OCaml rather than writing SQL code.
+* [PG'OCaml](https://github.com/darioteixeira/pgocaml): PostgreSQL client in pure OCaml. Includes a `PPX` that provides compile-time checking of SQL syntax and types.
+* [PGX](https://github.com/arenadotio/pgx): a pure-OCaml PostgreSQL client library, supporting Async, LWT, or synchronous operations.
+* [PostgreSQL-OCaml](https://mmottl.github.io/postgresql-ocaml/): a low-level interface to PostgreSQL through the C API (`libpq`).
+* [ppx_mysql](https://github.com/issuu/ppx_mysql): Syntax extension for mysql bindings. [Blog post](https://engineering.issuu.com/2019/05/06/announcing-ppx-mysql).
+* [ppx_pgsql](https://github.com/tizoc/ppx_pgsql): a syntax extension for embedded SQL queries using PG'OCaml.
+* [ppx_rapper](https://github.com/roddyyaga/ppx_rapper): a syntax extension for PostgreSQL using Caqti
+* [SQLite3-OCaml](https://github.com/mmottl/sqlite3-ocaml/): OCaml bindings to the SQLite3 database.
+* [Sqlite3EZ](https://mlin.github.io/ocaml-sqlite3EZ/): thin wrapper for SQLite3 with a simplified interface.
 
 ### Out of Date
-* [Sequoia](https://github.com/andrenth/sequoia):
-(Needs update to latest OCaml)
-Create type-safe queries. Currently with bindings to MySQL/MariaDB and SQLite.
-* [mysql](http://ocaml-mysql.forge.ocamlcore.org/):
-(Older version of mysql)
-mysql library.
+
+* [mysql](http://ocaml-mysql.forge.ocamlcore.org/): (Older version of mysql) mysql library.
+* [Sequoia](https://github.com/andrenth/sequoia): (Needs update to latest OCaml) Create type-safe queries. Currently with bindings to MySQL/MariaDB and SQLite.
 
 ## OCaml Databases
 
+* [Arakoon](https://github.com/openvstorage/arakoon): a consistent distributed key-value store built on top of Tokyo Cabinet.
 * [Irmin](https://github.com/mirage/irmin): a distributed database that follows the same design principles as Git.
   * A fairly through tutorial for Irmin can be found [here](https://irmin.io/tutorial/introduction).
 * [Obigstore](http://obigstore.forge.ocamlcore.org/): a database with BigTable-like data model atop LevelDB.
 * [RunOrg](https://github.com/RunOrg/RunOrg): a WIP database server written in OCaml.
-* [Arakoon](https://github.com/openvstorage/arakoon): a consistent distributed key-value store built on top of Tokyo Cabinet.
 
 ## Overlays
 


### PR DESCRIPTION
Some updates for the databases page.

I broke the PR up into 4 commits with each one being more of a substantial change than the last in case you disagree with anything.

1. Add petrol to list of libs
2. Sort all the libraries within subheadings
3. Put additional info as sub-bullet points
4. Marked any libraries with >= 100 github stars as "popular"

That last commit in particular you may disagree with.  Rationale was, since the list is fairly long, I though it may be good to have a way to call out popular libraries.  100 github stars may not be the best way though.  

Let me know if you want to remove any of the four commits.

(See https://github.com/OCamlverse/ocamlverse.github.io/issues/173)