### PR TITLE
Add Climate in Command Line Arguments page

### DIFF
--- a/content/command_line.md
+++ b/content/command_line.md
@@ -25,3 +25,4 @@ which takes a similar approach to Cmdliner.
 * [Minicli](https://github.com/UnixJunkie/minicli)  is a self-described minimalist library
 for command line parsing.
 * [Quick-and-dirty pure command-line arguments in OCaml](https://dev.to/yawaramin/quick-and-dirty-pure-command-line-arguments-in-ocaml-3hcg) (using the standard Library's Arg module)
+* [Climate](https://github.com/gridbugs/climate) A declarative command-line parser with (quite) intuitive direct-style arguments parsers.


### PR DESCRIPTION
Add the Climate (https://github.com/gridbugs/climate) library to the command line arguments page, having used it, I currently prefer it to Cmdliner.