### PR TITLE
Update web_networking.md

### DIFF
--- a/content/web_networking.md
+++ b/content/web_networking.md
@@ -6,9 +6,9 @@ tags: [ecosystem]
 
 ## Articles
 
+* [Overview on libraries in 2025 by Tarides](https://tarides.com/blog/2025-05-15-ocaml-web-development-essential-tools-and-libraries-in-2025/)
 * [Full stack development in OCaml](https://ceramichacker.com/blog/26-1x-full-stack-webdev-in-ocaml-intro):
   Uses `Dream`, `Bonsai` and `GraphQL`.
-* [ICFP presentation on improving the OCaml web stack](https://www.youtube.com/watch?v=tTqqu4xh4UY&t=1156s)
 * [Building an OCaml webapp using Opium](https://shonfeder.gitlab.io/ocaml_webapp/)
 
 ## HTTP Servers
@@ -92,7 +92,7 @@ Can be compiled to Unix as well.
 
 * [h2](https://github.com/anmonteiro/ocaml-h2):
 High performance http2 implementation.
-* [httpaf](https://github.com/inhabitedtype/httpaf):
+* [h1](https://github.com/robur-coop/ocaml-h1):
 A high performance HTTP implementation written in OCaml. Compatible with Async and Lwt.
 * [cohttp](https://github.com/mirage/ocaml-cohttp):
 Older, slower implementation of HTTP supporting only HTTP/1.x.
@@ -132,9 +132,9 @@ and some frameworks work on making DOM manipulation more efficient.
 
 * [ocaml-vdom](https://github.com/LexiFi/ocaml-vdom):
 A version of virtual DOM manipulation that goes well with Ocsigen.
-* [incr_dom](https://github.com/janestreet/incr_dom):
+* [Bonsai](https://opensource.janestreet.com/bonsai/):
 Jane Street's version of virtual DOM,
-backed by the very powerful [Incremental](https://github.com/janestreet/incremental) library.
+backed by the very powerful [Incremental](https://github.com/janestreet/incremental) library. Successor of the [incr_dom](https://github.com/janestreet/incr_dom) library.
 
 ## Protocol Libraries
 


### PR DESCRIPTION
Some entries were a bit out-of-date.

Changes:
- There is an overview article by Tarides, I've included that.
- The ICFP presentation from 8 years ago doesn't seem that relevant for someone deciding on which tool to use now.
- httpaf is no longer maintained and has been succeeded by h1. There is also httpun which supported more features for some time. Apparently, that is no longer true though I haven't checked that in much detail. h1 is the endorsed fork so I've chosen that. See also https://github.com/robur-coop/ocaml-h1/issues/12
- incr_dom has been succeeded by Bonsai. This could maybe also be under web framework but it certainly also fits under VDOM.